### PR TITLE
Fix link to the Suspending sequence example

### DIFF
--- a/kotlin-coroutines-informal.md
+++ b/kotlin-coroutines-informal.md
@@ -1115,7 +1115,7 @@ for (value in seq) { // suspend while waiting for producer
 ```
 
 > You can find a worked out example with some logging that illustrates the execution
-  [here](examples/suspendingSequence-example.kt)
+  [here](examples/suspendingSequence/suspendingSequence-example.kt)
 
 ### Channels
 


### PR DESCRIPTION
Replace the link to the `Suspending sequence example` for the correct one