### PR TITLE
Small correction in text

### DIFF
--- a/kotlin-coroutines-informal.md
+++ b/kotlin-coroutines-informal.md
@@ -118,7 +118,7 @@ launch(CommonPool) {
 }
 ```
 
-The `aRead()` and `aWrite()` here are special _suspending functions_ — they _suspend_ execution 
+The `aRead()` and `aWrite()` here are special _suspending functions_ — they can _suspend_ execution 
 (which does not mean blocking the thread it has been running on) and _resume_ when the call has completed. 
 If we squint our eyes just enough to imagine that all the code after `aRead()` has been wrapped in a 
 lambda and passed to `aRead()` as a callback, and the same has been done for `aWrite()`, 


### PR DESCRIPTION
1. Suspending functions doesn't need to suspend execution
2. Function is actually suspended when primitive is called, not when suspending function is called