### PR TITLE
fix the resumeWith method signature to match as that in Continuation …

### DIFF
--- a/examples/context/pool.kt
+++ b/examples/context/pool.kt
@@ -26,7 +26,8 @@ private class PoolContinuation<T>(
 ) : Continuation<T> {
     override val context: CoroutineContext = cont.context
 
-    override fun resumeWith(result: Result<T>) {
-        pool.execute { cont.resumeWith(result) }
+    override fun resumeWith(result: SuccessOrFailure<T>) {
+        pool.execute { cont.resumeWith(result)}
     }
+
 }

--- a/examples/context/swing.kt
+++ b/examples/context/swing.kt
@@ -9,9 +9,10 @@ object Swing : AbstractCoroutineContextElement(ContinuationInterceptor), Continu
 }
 
 private class SwingContinuation<T>(val cont: Continuation<T>) : Continuation<T> {
+
     override val context: CoroutineContext = cont.context
 
-    override fun resumeWith(result: Result<T>) {
+    override fun resumeWith(result: SuccessOrFailure<T>) {
         SwingUtilities.invokeLater { cont.resumeWith(result) }
     }
 }

--- a/examples/context/threadContext.kt
+++ b/examples/context/threadContext.kt
@@ -29,7 +29,7 @@ class ThreadContext(
     private inner class ThreadContinuation<T>(val cont: Continuation<T>) : Continuation<T>{
         override val context: CoroutineContext = cont.context
 
-        override fun resumeWith(result: Result<T>) {
+        override fun resumeWith(result: SuccessOrFailure<T>) {
             executor.execute { cont.resumeWith(result) }
         }
     }

--- a/examples/future/future.kt
+++ b/examples/future/future.kt
@@ -8,9 +8,11 @@ fun <T> future(context: CoroutineContext = CommonPool, block: suspend () -> T): 
         CompletableFutureCoroutine<T>(context).also { block.startCoroutine(completion = it) }
 
 class CompletableFutureCoroutine<T>(override val context: CoroutineContext) : CompletableFuture<T>(), Continuation<T> {
-    override fun resumeWith(result: Result<T>) {
-        result
-            .onSuccess { complete(it) }
-            .onFailure { completeExceptionally(it) }
+    override fun resumeWith(result: SuccessOrFailure<T>) {
+        if(result.isSuccess) {
+            complete(result.getOrNull())
+        }else {
+            completeExceptionally(result.exceptionOrNull())
+        }
     }
 }

--- a/examples/generator/generator.kt
+++ b/examples/generator/generator.kt
@@ -66,9 +66,11 @@ internal class GeneratorCoroutine<T, R>: Generator<T, R>, GeneratorBuilder<T, R>
 
     override val context: CoroutineContext get() = EmptyCoroutineContext
 
-    override fun resumeWith(result: Result<Unit>) {
-        result
-            .onSuccess { lastValue = null }
-            .onFailure { lastException = it }
+    override fun resumeWith(result: SuccessOrFailure<Unit>) {
+        if (result.isSuccess) {
+            lastValue = null
+        }else {
+            lastException = result.exceptionOrNull()
+        }
     }
 }

--- a/examples/run/runBlocking.kt
+++ b/examples/run/runBlocking.kt
@@ -9,7 +9,7 @@ fun <T> runBlocking(context: CoroutineContext, block: suspend () -> T): T =
 private class BlockingCoroutine<T>(override val context: CoroutineContext) : Continuation<T> {
     private val lock = ReentrantLock()
     private val done = lock.newCondition()
-    private var result: Result<T>? = null
+    private var result: SuccessOrFailure<T>? = null
 
     private inline fun <T> locked(block: () -> T): T {
         lock.lock()
@@ -26,7 +26,7 @@ private class BlockingCoroutine<T>(override val context: CoroutineContext) : Con
         }
     }
 
-    override fun resumeWith(result: Result<T>) = locked {
+    override fun resumeWith(result: SuccessOrFailure<T>) {
         this.result = result
         done.signal()
     }

--- a/examples/sequence/optimized/sequenceOptimized.kt
+++ b/examples/sequence/optimized/sequenceOptimized.kt
@@ -19,8 +19,8 @@ class SequenceCoroutine<T>: AbstractIterator<T>(), SequenceScope<T>, Continuatio
     // Completion continuation implementation
     override val context: CoroutineContext get() = EmptyCoroutineContext
 
-    override fun resumeWith(result: Result<Unit>) {
-        result.getOrThrow()
+    override fun resumeWith(result: SuccessOrFailure<Unit>) {
+        result.getOrThrow() // bail out on error
         done()
     }
 

--- a/examples/sequence/sequence.kt
+++ b/examples/sequence/sequence.kt
@@ -24,7 +24,7 @@ private class SequenceCoroutine<T>: AbstractIterator<T>(), SequenceScope<T>, Con
     // Completion continuation implementation
     override val context: CoroutineContext get() = EmptyCoroutineContext
 
-    override fun resumeWith(result: Result<Unit>) {
+    override fun resumeWith(result: SuccessOrFailure<Unit>) {
         result.getOrThrow() // bail out on error
         done()
     }

--- a/examples/suspendingSequence/suspendingSequence.kt
+++ b/examples/suspendingSequence/suspendingSequence.kt
@@ -95,16 +95,14 @@ class SuspendingIteratorCoroutine<T>(
     }
 
     // Completion continuation implementation
-    override fun resumeWith(result: Result<Unit>) {
+    override fun resumeWith(result: SuccessOrFailure<Unit>) {
         nextStep = null
-        result
-            .onSuccess {
-                resumeIterator(false)
-            }
-            .onFailure { exception ->
-                state = State.DONE
-                computeContinuation!!.resumeWithException(exception)
-            }
+        if (result.isSuccess) {
+            resumeIterator(false)
+        }else {
+            state = State.DONE
+            computeContinuation!!.resumeWithException(result.exceptionOrNull()!!)
+        }
     }
 
     // Generator implementation


### PR DESCRIPTION
Based on the below definition fix the usage at various places which were using the old signature 
plugins {
    id 'org.jetbrains.kotlin.jvm' version '1.3'
}
`@SinceKotlin("1.3")
public interface Continuation<in T> {
    /**
     * Context of the coroutine that corresponds to this continuation.
     */
    // todo: shall we provide default impl with EmptyCoroutineContext?
    public val context: CoroutineContext

    /**
     * Resumes the execution of the corresponding coroutine passing successful or failed [result] as the
     * return value of the last suspension point.
     */
    public fun resumeWith(result: SuccessOrFailure<T>)
}`

**Old interface definition** 
plugins {
    id 'org.jetbrains.kotlin.jvm' version '1.2.60'
}

`
/**
 * Interface representing a continuation after a suspension point that returns value of type `T`.
 */
@SinceKotlin("1.3")
public interface Continuation<in T> {
    /**
     * Context of the coroutine that corresponds to this continuation.
     */
    // todo: shall we provide default impl with EmptyCoroutineContext?
    public val context: CoroutineContext

    /**
     * Resumes the execution of the corresponding coroutine passing successful or failed [result] as the
     * return value of the last suspension point.
     */
    public fun resumeWith(result: Result<T>)
}
`